### PR TITLE
Fix error while setting group: EPERM: Operation not permitted

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,20 +214,20 @@ impl Daemonizr {
             return Err(DaemonizrError::FailedToSetsid(e.to_string()));
         }
 
-        // setuid()
-        match self.user {
-            User::Id(u) => {
-                if let Err(e) = setuid(Uid::from_raw(u)) {
-                    return Err(DaemonizrError::FailedToSetUser(u, e.to_string()));
-                }
-            }
-        }
-
         // setgid()
         match self.group {
             Group::Id(g) => {
                 if let Err(e) = setgid(Gid::from_raw(g)) {
                     return Err(DaemonizrError::FailedToSetGroup(g, e.to_string()));
+                }
+            }
+        }
+
+        // setuid()
+        match self.user {
+            User::Id(u) => {
+                if let Err(e) = setuid(Uid::from_raw(u)) {
+                    return Err(DaemonizrError::FailedToSetUser(u, e.to_string()));
                 }
             }
         }


### PR DESCRIPTION
I've spent quite some time debugging the issue while developing my small rust app:
```
[2025-06-07T21:21:43Z ERROR ollana::serve_app] Failed to daemonize the application
Error: failed to set group to GID 998: EPERM: Operation not permitted
```
This is the code I have:
```
            let user = User::by_name("ollana")?;
            let group = Group::by_name("ollana")?;
            let daemonizr = Daemonizr::new().work_dir(PathBuf::from("/var/lib/ollana"))?;
            let daemonizr = daemonizr.umask(0o137)?;
            let daemonizr = daemonizr
                .pidfile(PathBuf::from("/run/ollana/ollana.pid"))
                .as_user(user)
                .as_group(group)
                .stdout(Stdout::Redirect(PathBuf::from("/var/log/ollana/serve.log")))
                .stderr(Stderr::Redirect(PathBuf::from("/var/log/ollana/serve.log")));

            match daemonizr.spawn() {
                Ok(_) => {
                    info!("Running in daemon mode");
                }
                Err(error) => {
                    error!("Failed to daemonize the application");
                    return Err(anyhow::Error::new(error));
                }
            }
```

The answer found on Stack Overflow helped me to debug and fix it: https://stackoverflow.com/a/11062896

> I suspect you're calling setuid before setgid. As soon as you call
setuid to change the uid to something other than root, you've forfeited your permission to change the gid to an arbitrary value. You must call setgid first, then setuid.

Solution: setgid must be called before setuid

Confirmed it works by testing locally.